### PR TITLE
dprnn first commit

### DIFF
--- a/asteroid/masknn/blocks.py
+++ b/asteroid/masknn/blocks.py
@@ -182,7 +182,8 @@ class DPRNNBlock(nn.Module):
         in_chan: int. Number of input channels.
         hid_size: int. Number of hidden neurons in the RNNs.
         norm_type: string. Type of normalization to use.
-            Among `LN` (2D Layernorm).
+            Among `gLN` (global Layernorm), `cLN` (channelwise Layernorm) and
+            `cgLN` (cumulative global Layernorm).
         bidirectional: bool. True for bidirectional Inter-Chunk RNN.
         rnn_type: string. Type of RNN used.
             Choose between 'RNN', 'LSTM' and 'GRU'.
@@ -194,7 +195,7 @@ class DPRNNBlock(nn.Module):
         Luo, Yi, Zhuo Chen, and Takuya Yoshioka.
         https://arxiv.org/abs/1910.06379
     """
-    def __init__(self, in_chan, hid_size, norm_type="LN",
+    def __init__(self, in_chan, hid_size, norm_type="gLN",
                  bidirectional=True, rnn_type="LSTM", num_layers=1, dropout=0):
         super(DPRNNBlock, self).__init__()
         self.intra_RNN=SingleRNN(rnn_type, in_chan, hid_size, num_layers, dropout=dropout, bidirectional=True)
@@ -322,7 +323,7 @@ class DPRNN(SubModule):
             'out_chan': self.out_chan,
             'bn_chan': self.bn_chan,
             'hid_size': self.hid_size,
-            'chunk_size': self.kernel_size,
+            'chunk_size': self.chunk_size,
             'hop_size': self.hop_size,
             'n_repeats': self.n_repeats,
             'n_src': self.n_src,

--- a/asteroid/masknn/blocks.py
+++ b/asteroid/masknn/blocks.py
@@ -4,6 +4,7 @@ NN blocks for separators.
 """
 
 from torch import nn
+from torch.nn.functional import fold, unfold
 
 from . import norms, activations
 from ..utils import has_arg
@@ -138,5 +139,199 @@ class TDConvNet(SubModule):
             'n_src': self.n_src,
             'norm_type': self.norm_type,
             'mask_act': self.mask_act
+        }
+        return config
+
+class SingleRNN(nn.Module):
+    """
+    From https://github.com/yluo42/TAC/blob/master/utility/models.py
+    Container module for a single RNN layer.
+
+    args:
+        rnn_type: string, select from 'RNN', 'LSTM', 'GRU'.
+        input_size: int, dimension of the input feature. The input should have shape
+                    (batch, seq_len, input_size).
+        hidden_size: int, dimension of the hidden state.
+        dropout: float, dropout ratio. Default is 0.
+        n_layers: int > 0. number of layers used in RNN.
+        bidirectional: bool, whether the RNN layers are bidirectional. Default is False.
+    """
+
+    def __init__(self, rnn_type, input_size, hidden_size, n_layers=1, dropout=0, bidirectional=False):
+        super(SingleRNN, self).__init__()
+
+        assert rnn_type in ["RNN", "LSTM", "GRU"]
+        self.rnn_type = rnn_type
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.num_direction = int(bidirectional) + 1
+
+        self.rnn = getattr(nn, rnn_type)(input_size, hidden_size, num_layers=n_layers,
+                                             dropout=dropout, batch_first=True, bidirectional=bool(bidirectional))
+
+        # linear projection layer
+        self.proj = nn.Linear(hidden_size * self.num_direction, input_size)
+
+    def forward(self, input):
+        # input shape: batch, seq, dim
+        output = input
+        rnn_output, _ = self.rnn(output)
+        rnn_output = self.proj(rnn_output)
+        return rnn_output
+
+
+class DPRNNBlock(nn.Module):
+    """Dual-Path RNN Block as proposed in [1].
+
+    Args
+        in_chan: int. Number of input channels.
+        hid_size: int. Number of hidden neurons in the RNNs.
+        norm_type: string. Type of normalization to use.
+            Among `LN` (2D Layernorm).
+        bidirectional: bool. True for bidirectional Inter-Chunk RNN.
+        rnn_type: string. Type of RNN used.
+            Choose between 'RNN', 'LSTM' and 'GRU'.
+        num_layers: int>0. Number of layers used in each RNN.
+        dropout: int in (0,1).
+
+    References :
+        [1] : "Dual-path RNN: efficient long sequence modeling for time-domain single-channel speech separation",
+        Luo, Yi, Zhuo Chen, and Takuya Yoshioka.
+        https://arxiv.org/abs/1910.06379
+    """
+    def __init__(self, in_chan, hid_size, norm_type="LN",
+                 bidirectional=True, rnn_type="LSTM", num_layers=1, dropout=0):
+        super(DPRNNBlock, self).__init__()
+        self.intra_RNN=SingleRNN(rnn_type, in_chan, hid_size, num_layers, dropout=dropout, bidirectional=True)
+        self.intra_norm=norms.get(norm_type)(in_chan)
+        self.inter_RNN=SingleRNN(rnn_type, in_chan, hid_size, num_layers, dropout=dropout, bidirectional=bidirectional)
+        self.inter_norm = norms.get(norm_type)(in_chan)
+
+
+    def forward(self, x):
+        # x is [batch, num_features, chunk_size, num_chunks]
+        B, N, K, L = x.size()
+        output = x # for skip connection
+        # intra-chunk processing
+        x = x.transpose(1, -1).reshape(B * L, K, N)
+        x = self.intra_RNN(x)
+        x = x.reshape(B, L, K, N).transpose(1, -1)
+        x = self.intra_norm(x)
+        output = output + x
+        # inter-chunk processing
+        output = output.transpose(1, 2).transpose(2, -1).reshape(B * K, L, N)
+        output = self.inter_RNN(output)
+        output = output.reshape(B, K, L, N).transpose(1, -1).transpose(2, -1)
+        output = self.inter_norm(output)
+        return output + x
+
+
+class DPRNN(SubModule):
+    """ Dual-path RNN Network for Single-Channel Source Separation introduced in [1].
+    Args
+        in_chan: int > 0. Number of input filters.
+        out_chan : int > 0. Number of bins in the estimated masks.
+        bn_chan: int > 0. Number of channels after the bottleneck.
+        hid_size: int > 0. Number of neurons in the RNNs.
+        kernel_size: int > 0. Kernel size in convolutional blocks.
+        n_blocks: int > 0. Number of convolutional blocks in each repeat.
+        n_repeats: int > 0. Number of repeats.
+        n_src: int > 0. Number of masks to estimate.
+        norm_type: string. Among [BN, gLN, cLN]
+        mask_act: string. Which non-linear function to generate mask.
+        bidirectional: bool: True for bidirectional Inter-Chunk RNN (Intra-Chunk is always bidirectional).
+        rnn_type: string. Type of RNN used. Choose between 'RNN', 'LSTM' and 'GRU'.
+        num_layers: number of layers in each RNN.
+        dropout: int in (0,1).
+
+    References :
+        [1] : "Dual-path RNN: efficient long sequence modeling for time-domain single-channel speech separation",
+        Luo, Yi, Zhuo Chen, and Takuya Yoshioka.
+        https://arxiv.org/abs/1910.06379
+    """
+    def __init__(self, in_chan, out_chan, bn_chan, hid_size,
+                 chunk_size, hop_size, n_repeats, n_src, norm_type="LN",
+                 mask_act='sigmoid', bidirectional=True, rnn_type="LSTM", num_layers=1, dropout=0):
+        super(DPRNN, self).__init__()
+        self.in_chan = in_chan
+        self.out_chan = out_chan
+        self.bn_chan = bn_chan
+        self.hid_size = hid_size
+        self.chunk_size = chunk_size
+        self.hop_size = hop_size
+        self.n_repeats = n_repeats
+        self.n_src = n_src
+        self.norm_type = norm_type
+        self.mask_act = mask_act
+        self.bidirectional = bidirectional
+        self.rnn_type = rnn_type
+        self.num_layers = num_layers
+        self.dropout=dropout
+
+        layer_norm = norms.get(norm_type)(in_chan)
+        bottleneck_conv = nn.Conv1d(in_chan, bn_chan, 1)
+        self.bottleneck = nn.Sequential(layer_norm, bottleneck_conv)
+
+        net = [] # Succession of DPRNNBlocks.
+        for x in range(self.n_repeats):
+            net += [DPRNNBlock(bn_chan, hid_size, norm_type, bidirectional, rnn_type, num_layers, dropout)]
+        self.net = nn.Sequential(*net)
+
+        # TODO Luo's code uses Conv2D in TAC not clear in [1] if it is also used Conv2D.
+        # This version with Conv1D however has been able to reach same results as in [1].
+        mask_conv = nn.Conv1d(bn_chan, n_src*out_chan, 1)
+        self.mask_net = nn.Sequential(nn.PReLU(), mask_conv)
+
+        # Get activation function. For softmax, feed the source dimension.
+        if mask_act.lower() == 'linear':
+            mask_nl_class = NoLayer
+        else:
+            mask_nl_class = getattr(nn, mask_act)
+        if has_arg(mask_nl_class, 'dim'):
+            self.output_act = mask_nl_class(dim=1)
+        else:
+            self.output_act = mask_nl_class()
+
+    def forward(self, mixture_w):
+        """
+        Args:
+            mixture_w: torch.Tensor of shape [batch, n_filters, n_frames]
+        Returns:
+            est_mask: torch.Tensor of shape [batch, n_src, n_filters, n_frames]
+        """
+        batch, n_filters, n_frames = mixture_w.size()
+        output = self.bottleneck(mixture_w) # [batch x bn_chan x n_frames]
+        output = unfold(output.unsqueeze(-1), kernel_size=(self.chunk_size, 1), padding=(self.chunk_size, 0),
+                        stride=(self.hop_size, 1))
+        S = output.size(-1)
+        output = output.reshape(batch, self.bn_chan, self.chunk_size, S) # [batch x bn_chan x chunk_size x n_chunks]
+        output = self.net(output) # apply stacked DPRNN Blocks sequentially
+        # overlap and add: [batch x bn_chan x chunk_size x n_chunks] -> [batch x bn_chan x n_frames]
+        output = fold(output.reshape(batch, self.bn_chan * self.chunk_size, S),
+                                 (n_frames, 1), kernel_size=(self.chunk_size, 1),
+                                 padding=(self.chunk_size, 0),
+                                 stride=(self.hop_size, 1))
+        output = output.squeeze(-1) / (self.K / self.P) # normalization
+        score = self.mask_net(output)
+        score = score.view(batch, self.n_src, self.out_chan, n_frames)
+        est_mask = self.output_act(score)
+        return est_mask
+
+    def get_config(self):
+        config = {
+            'in_chan': self.in_chan,
+            'out_chan': self.out_chan,
+            'bn_chan': self.bn_chan,
+            'hid_size': self.hid_size,
+            'chunk_size': self.kernel_size,
+            'hop_size': self.hop_size,
+            'n_repeats': self.n_repeats,
+            'n_src': self.n_src,
+            'norm_type': self.norm_type,
+            'mask_act': self.mask_act,
+            'bidirectional': self.bidirectional,
+            'rnn_type': self.rnn_type,
+            'num_layers': self.num_layers,
+            'dropout': self.dropout
         }
         return config

--- a/asteroid/masknn/norms.py
+++ b/asteroid/masknn/norms.py
@@ -72,35 +72,11 @@ class CumLN(_LayerNorm):
         return self.gamma * (x - cum_mean) / (cum_var + EPS).sqrt() + self.beta
 
 
-class LayerNorm2D(nn.Module):
-    """2D Layer Normalization (LN)"""
-    def __init__(self, channel_size):
-        super(LayerNorm2D, self).__init__()
-        self.gamma = nn.Parameter(torch.Tensor(1, channel_size, 1, 1))  # [1, N, 1, 1] 3-d batched tensor
-        self.beta = nn.Parameter(torch.Tensor(1, channel_size,1, 1))  # [1, N, 1, 1]
-        self.reset_parameters()
-
-    def reset_parameters(self):
-        self.gamma.data.fill_(1)
-        self.beta.data.zero_()
-
-    def forward(self, x):
-        """
-        Args:
-            x: [M, N, X, Y], M is batch size, N is channel size, X and Y spatial dimensions
-        Returns:
-            LN_x: [M, N, X, Y]
-        """
-        mean = x.mean(dim=1, keepdim=True).mean(dim=2, keepdim=True).mean(dim=3, keepdim=True)
-        var = (torch.pow(x-mean, 2)).mean(dim=1, keepdim=True).mean(dim=2, keepdim=True).mean(dim=3, keepdim=True)
-        LN_y = self.gamma * (x - mean) / torch.pow(var + EPS, 0.5) + self.beta
-        return LN_y
-
 # Aliases.
 gLN = GlobLN
 cLN = ChanLN
 cgLN = CumLN
-LN = LayerNorm2D
+
 
 def get(identifier):
     if identifier is None:


### PR DESCRIPTION
Added the DPRNN architecture. In Luo's TAC Conv2D is used for mask net. I have only tested this version which instead is more similar to plain ConvTasNet. 
Had to include also a 2D LayerNorm layer. 
Probably there is a better way and the vanilla _LayerNorm can be made compatible with 2D inputs 