### PR TITLE
Api doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/apidoc
 
 # PyBuilder
 target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 
 install:
     - pip install -e .[tests]
+    - pip install -r requirements.txt
 
 script:
     - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
     - cd docs
     - make doc
     - make html
-    - touch build/html/.nojekyll  # do not use jekyll to build doc
+    - touch build/html/.nojekyll  # prevents use jekyll to build doc
 
 deploy:
     provider: pages
@@ -25,4 +25,4 @@ deploy:
     github_token: $GITHUB_PAGES
     local_dir: docs/build/html
     on:
-      all_branches: true
+      branches: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,14 @@ install:
 script:
     - python --version
     - py.test
+    - cd docs
+    - make doc
+    - make html
+
+deploy:
+    provider: pages
+    skip_cleanup: true
+    keep_history: true
+    github_token: $GITHUB_PAGES
+    local_dir: docs/build/html
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
     - cd docs
     - make doc
     - make html
-    - touch build/html/.nojekyll  # prevents use jekyll to build doc
+    - touch build/html/.nojekyll  # do not use jekyll to build doc
 
 deploy:
     provider: pages
@@ -25,4 +25,4 @@ deploy:
     github_token: $GITHUB_PAGES
     local_dir: docs/build/html
     on:
-      branches: master
+      all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ deploy:
     keep_history: true
     github_token: $GITHUB_PAGES
     local_dir: docs/build/html
-
+    on:
+      all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ script:
     - cd docs
     - make doc
     - make html
+    - touch build/html/.nojekyll  # do not use jekyll to build doc
 
 deploy:
     provider: pages
     skip_cleanup: true
-    keep_history: true
+    keep_history: false
     github_token: $GITHUB_PAGES
     local_dir: docs/build/html
     on:

--- a/asteroid/data/__init__.py
+++ b/asteroid/data/__init__.py
@@ -1,0 +1,1 @@
+from .wham_dataset import WhamDataset

--- a/asteroid/data/wav.py
+++ b/asteroid/data/wav.py
@@ -1,27 +1,26 @@
 """
-Utils used to handle a wav file
-@author: Sunit Sivasankaran, Inria-Nancy
+| Utils used to handle a wav file
+| @author: Sunit Sivasankaran, Inria-Nancy
 """
 
 import os
 import numpy as np
 import soundfile as sf
-import ipdb
+# import ipdb
 
 
 class SingleWav(object):
-    """
-    Interface to handle a single wav file
+    """ Interface to handle a single wav file
 
-    # Arguments
-        file_name: The path to the wav file
-        channel_interest: An array of interested channels.
+    Args:
+        file_name (str): The path to the wav file
+        channel_interest (list[int]): An array of interested channels.
             Used in case of multichannel signals
         wav_id: An id to identify the wav file
-        save: Boolean, Save the data untill the object is destroyed if True
+        save (bool): Save the data untill the object is destroyed if True
 
-    # Example
-        SingleWav('/home/test.wav')
+    Examples:
+        >>> SingleWav('/home/test.wav')
 
     """
     def __init__(self, file_name, channel_interest=None, \
@@ -40,19 +39,16 @@ class SingleWav(object):
             self.channel_interest = np.array(channel_interest)
 
     def verify(self):
-        """
-        Verify if all the information is good
-        """
+        """ Verify if all the information is good """
         assert os.path.exists(self.file_name),\
             self.file_name +' does not exists'
 
 
     def update_info(self):
-        """
-            Get wav related info and place it in the
-            `info` variable.
-            Note: Avoid calling this in the `__init__` section. Very time
-                consuming
+        """ Get wav related info and place it in the :attr:`info` variable.
+
+        .. note:: Avoid calling this in the `__init__` section. Very time
+            consuming
         """
         if self.info is None:
             self.info = sf.info(self.file_name)
@@ -62,10 +58,10 @@ class SingleWav(object):
 
     @property
     def wav_len(self):
-        """
-            Get the sample length of the signal
-        #Returns
-            A number of samples in wav
+        """ Get the sample length of the signal
+
+        Returns:
+            int: Wav length in number of samples
         """
         if self.sample_len is None:
             self.update_info()
@@ -73,10 +69,11 @@ class SingleWav(object):
 
     @property
     def data(self):
-        """
-            Read the wav file if not saved
-        #Returns
-            A two dimensional numpy array of shape [samples, channels]
+        """ Read the wav file if not saved
+
+        Returns:
+           :class:`numpy.ndarray`:
+                Two dimensional array of shape [samples, channels]
         """
         self.update_info()
         if self.__wav_data is not None:
@@ -99,20 +96,23 @@ class SingleWav(object):
             self.__wav_data = None
 
     def save_space(self):
-        """ Remove the saved data. self.data will read from the file again.
+        """ Remove the saved data.
+
+        self.data will read from the file again.
         """
         self.__wav_data = None
 
     def temp_save(self):
-        """ Temporarily save the wav data. Call `save_space` to remove it.
+        """ Temporarily save the wav data.
+
+        Call :func:`save_space` to remove it.
         """
         self.__wav_data = self.data
 
 
     @property
     def wav_id(self):
-        """getter for the wav id
-        """
+        """ Get wav id """
         return self.__id
 
     @wav_id.setter
@@ -120,19 +120,18 @@ class SingleWav(object):
         self.__id = value
 
     def write_wav(self, path):
-        """ Write the wav data into an other path
-        """
+        """ Write the wav data into an other path """
         sf.write(path, self.data, self.sampling_rate)
 
 class MultipleWav(SingleWav):
-    """
-        Handle a set of wav files as a single object.
-    # Arguments
-        file_name_list: A list of wav file names
-        channel_interest: An array of interested channels.
+    """ Handle a set of wav files as a single object.
+
+    Args:
+        file_name_list (list[str]): List of wav file names
+        channel_interest (list[int]): An array of interested channels.
             Used in case of multichannel signals
         wav_id: An id to identify the bunch of wav file
-        save: Boolean, Save the data untill the object is destroyed if True
+        save (bool): Save the data until the object is destroyed if True
 
     """
     def __init__(self, file_name_list, channel_interest=None, \
@@ -168,9 +167,11 @@ class MultipleWav(SingleWav):
 
     @property
     def data(self):
-        """Reads all the files in the file list
-        #Returns
-            A list of wav signals
+        """ Reads all the files in the file list
+
+        Returns:
+            list[:class:`numpy.ndarray`]:
+                A list of wav signals
         """
         self.update_info()
         if self.__wav_data is not None:

--- a/asteroid/data/wham_dataset.py
+++ b/asteroid/data/wham_dataset.py
@@ -1,6 +1,6 @@
 """
-Wham Dataset class.
-@author : Manuel Pariente, Inria-Nancy
+| Wham Dataset class.
+| @author : Manuel Pariente, Inria-Nancy
 """
 import torch
 from torch.utils import data
@@ -39,17 +39,22 @@ WHAM_TASKS['enh_both'] = WHAM_TASKS['enhance_both']
 
 class WhamDataset(data.Dataset):
     """ Dataset class for WHAM source separation and speech enhancement tasks.
+
     Args:
-        json_dir: String, the path to the directory containing the json files.
-        task: String, one of `"enh_single"`, `"enh_both"`, `"sep_clean"` or
-            `"sep_noisy"`.
-            `"enh_single"` for single speaker speech enhancement.
-            `"enh_both"` for multi speaker speech enhancement.
-            `"sep_clean"` for two-speaker clean source separation.
-            `"sep_noisy"` for two-speaker noisy source separation.
-        sample_rate: Integer. The sampling rate of the wav files.
-        segment: Float. Length of the segments used for training, in seconds.
-        nondefault_nsrc: Integer. Number of sources in the training targets.
+        json_dir (str): The path to the directory containing the json files.
+        task (str): One of ``'enh_single'``, ``'enh_both'``, ``'sep_clean'`` or
+            ``'sep_noisy'``.
+
+            * ``'enh_single'`` for single speaker speech enhancement.
+            * ``'enh_both'`` for multi speaker speech enhancement.
+            * ``'sep_clean'`` for two-speaker clean source separation.
+            * ``'sep_noisy'`` for two-speaker noisy source separation.
+
+        sample_rate (int, optional): The sampling rate of the wav files.
+        segment (float, optional): Length of the segments used for training,
+            in seconds.
+        nondefault_nsrc (int, optional): Number of sources in the training
+            targets.
             If None, defaults to one for enhancement tasks and two for
             separation tasks.
     """

--- a/asteroid/engine/losses.py
+++ b/asteroid/engine/losses.py
@@ -2,9 +2,9 @@
 | Package-level utils.
 | @author : Manuel Pariente, Inria-Nancy
 
-| Modified and extended from `<github.com/kaituoxu/Conv-TasNet/>`_
+| Modified and extended from `<https://github.com/kaituoxu/Conv-TasNet/>`__
 | MIT Copyright (c) 2018 Kaituo XU
-| See also `<github.com/kaituoxu/Conv-TasNet/blob/master/LICENSE>`_
+| See also `<https://github.com/kaituoxu/Conv-TasNet/blob/master/LICENSE>`__.
 """
 
 from itertools import permutations

--- a/asteroid/engine/losses.py
+++ b/asteroid/engine/losses.py
@@ -144,7 +144,8 @@ def find_best_perm(pair_wise_losses, n_src):
     """Find the best permutation, given the pair-wise losses.
 
     Args:
-        pair_wise_losses (torch.Tensor): Pair-wise losses [batch, n_src, n_src]
+        pair_wise_losses (:class:`torch.Tensor`):
+            Tensor of shape [batch, n_src, n_src]. Pairwise losses.
         n_src (int): Number of sources.
 
     Returns:
@@ -175,11 +176,11 @@ def reorder_source(source, n_src, min_loss_idx):
         source torch.Tensor): Tensor of shape [batch, n_src, time]
         n_src (int): Number of sources.
         min_loss_idx (torch.LongTensor): Tensor of shape [batch],
-            each item is in [0, C!)  ``C! == n_src!``?
+            each item is in [0, n_src!).
 
     Returns:
         :class:`torch.Tensor`:
-            Reordered sources of shape [batch, n_src, time]
+            Reordered sources of shape [batch, n_src, time].
     """
     perms = source.new_tensor(list(permutations(range(n_src))),
                               dtype=torch.long)

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -23,11 +23,11 @@ class System(pl.LightningModule):
         config: Anything to be saved with the checkpoints during training.
             The config dictionary to re-instantiate the run for example.
 
-    By default, `training_step` (used by pytorch-lightning in the training
-    loop) and `validation_step` (used for the validation loop) share
-    `common_step`. If you want different behavior for the training loop and
-    the validation loop, overwrite both `training_step` and `validation_step`
-    instead.
+    .. note:: By default, `training_step` (used by pytorch-lightning in the
+        training loop) and `validation_step` (used for the validation loop)
+        share `common_step`. If you want different behavior for the training
+        loop and the validation loop, overwrite both `training_step` and
+        `validation_step` instead.
     """
     def __init__(self, model, optimizer, loss_class, train_loader,
                  val_loader=None, scheduler=None, config=None):
@@ -62,7 +62,7 @@ class System(pl.LightningModule):
             batch_nb (int): The number of the batch in the epoch.
 
         Returns:
-            float: The loss value on this batch.
+            :class:`torch.Tensor` : The loss value on this batch.
 
         .. note:: This is typically the method to overwrite when subclassing
             `System`. If the training and validation steps are different

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -8,34 +8,20 @@ import pytorch_lightning as pl
 
 
 class System(pl.LightningModule):
-    """ Base class for deep learning system.
+    """ Base class for deep learning systems.
     Subclass of pytorch_lightning.LightningModule.
     Contains a model, an optimizer, a loss_class and training and validation
     loaders and learning rate scheduler.
 
     Args:
-        model: nn.Module instance.
-        optimizer: torch.optim.Optimizer instance, or list of.
+        model (torch.nn.Module): Instance of model.
+        optimizer (torch.optim.Optimizer): Instance or list of optimizers.
         loss_class: Class with `compute` method. (More doc to come)
-        train_loader: torch.utils.data.DataLoader instance.
-        val_loader: torch.utils.data.DataLoader instance.
-        scheduler: torch.optim._LRScheduler instance, or list of.
+        train_loader (torch.utils.data.DataLoader): Training dataloader.
+        val_loader (torch.utils.data.DataLoader): Validation dataloader.
+        scheduler (torch.optim._LRScheduler): Instance, or list.
         config: Anything to be saved with the checkpoints during training.
             The config dictionary to re-instantiate the run for example.
-    Methods:
-        # From System
-        common_step : Common step between training and validation.
-        unpack_data : Unpacks batch from loaders.
-
-        # Overwritten from pl.LightningModule
-        forward: self.model.forward (Unused butrequired by PL)
-        training_step : Training step (doesn't include backward and GD)
-        validation_step : Validation step (forward and compute loss)
-        validation_end : Aggregates results and outputs logs.
-        configure_optimizer: return self.optimizer, self.scheduler by default.
-        train_dataloader: return self.train_loader
-        val_dataloader: return self.val_loader
-        on_checkpoint: adds self.config in checkpoint['training_config']
 
     By default, `training_step` (used by pytorch-lightning in the training
     loop) and `validation_step` (used for the validation loop) share
@@ -55,28 +41,33 @@ class System(pl.LightningModule):
         self.config = config
 
     def forward(self, *args, **kwargs):
-        """ Required by PL.
+        """ Applies forward pass.
+
+        Required by PL.
 
         Returns:
-            self.model.forward
+            :class:`torch.Tensor`
         """
         return self.model.forward(*args, **kwargs)
 
     def common_step(self, batch, batch_nb):
         """ Common forward step between training and validation.
+
         The function of this method is to unpack the data given by the loader,
         forward the batch through the model and compute the loss.
+
         Args:
             batch: the object returned by the loader (a list of torch.Tensor
                 in most cases) but can be something else.
-            batch_nb: The number of the batch in the epoch.
-        Returns:
-            The loss value on this batch.
+            batch_nb (int): The number of the batch in the epoch.
 
-        Note : this is typically the method to overwrite when subclassing
-        `System`. If the training and validation steps are different (except
-        for loss.backward() and optimzer.step()), then overwrite
-        `training_step` and `validation_step` instead.
+        Returns:
+            float: The loss value on this batch.
+
+        .. note:: This is typically the method to overwrite when subclassing
+            `System`. If the training and validation steps are different
+            (except for loss.backward() and optimzer.step()), then overwrite
+            `training_step` and `validation_step` instead.
         """
         inputs, targets, infos = self.unpack_data(batch)
         est_targets = self.model(inputs)
@@ -84,12 +75,13 @@ class System(pl.LightningModule):
         return loss
 
     def unpack_data(self, data):
-        """
-         Unpack data given by the DataLoader
+        """ Unpack data given by the DataLoader
+
         Args:
             data: list of 2 or 3 elements.
                 [model_inputs, training_targets, additional infos] or
                 [model_inputs, training_targets]
+
         Returns:
               model_inputs, training_targets, additional infos
         """
@@ -105,18 +97,59 @@ class System(pl.LightningModule):
         return inputs, targets, infos
 
     def training_step(self, batch, batch_nb):
-        """ Pass data through the model and compute the loss. """
+        """ Pass data through the model and compute the loss.
+
+        Backprop is **not** performed.
+
+        Args:
+            batch: the object returned by the loader (a list of torch.Tensor
+                in most cases) but can be something else.
+            batch_nb (int): The number of the batch in the epoch.
+
+        Returns:
+            dict:
+
+            ``'loss'``: loss
+
+            ``'log'``: dict with tensorboard logs
+
+        """
         loss = self.common_step(batch, batch_nb)
         tensorboard_logs = {'train_loss': loss}
         return {'loss': loss, 'log': tensorboard_logs}
 
     def validation_step(self, batch, batch_nb):
-        """ Need to overwrite PL validation_step to do validation. """
+        """ Need to overwrite PL validation_step to do validation.
+
+        Args:
+            batch: the object returned by the loader (a list of torch.Tensor
+                in most cases) but can be something else.
+            batch_nb (int): The number of the batch in the epoch.
+
+        Returns:
+            dict:
+
+            ``'val_loss'``: loss
+        """
         loss = self.common_step(batch, batch_nb)
         return {'val_loss': loss}
 
     def validation_end(self, outputs):
-        """ How to aggregate outputs of `validation_step` for logging."""
+        """ How to aggregate outputs of `validation_step` for logging.
+
+        Args:
+           outputs (List[dict]): List of validation losses, each with a
+           ``'val_loss'`` key
+
+        Returns:
+            dict: Average loss
+
+            ``'val_loss'``: Average loss on `outputs`
+
+            ``'log'``: Tensorboard logs
+
+            ``'progress_bar'``: Tensorboard logs
+        """
         avg_loss = torch.stack([x['val_loss'] for x in outputs]).mean()
         tensorboard_logs = {'val_loss': avg_loss}
         return {'val_loss': avg_loss, 'log': tensorboard_logs,

--- a/asteroid/engine/system.py
+++ b/asteroid/engine/system.py
@@ -138,7 +138,7 @@ class System(pl.LightningModule):
         """ How to aggregate outputs of `validation_step` for logging.
 
         Args:
-           outputs (List[dict]): List of validation losses, each with a
+           outputs (list[dict]): List of validation losses, each with a
            ``'val_loss'`` key
 
         Returns:

--- a/asteroid/filterbanks/__init__.py
+++ b/asteroid/filterbanks/__init__.py
@@ -1,6 +1,6 @@
 """
-Convenient methods for filterbanks.
-@author : Manuel Pariente, Inria-Nancy
+| Convenient methods for filterbanks.
+| @author : Manuel Pariente, Inria-Nancy
 """
 from .analytic_free_fb import AnalyticFreeFB
 from .free_fb import FreeFB
@@ -11,36 +11,40 @@ from .enc_dec import Encoder, Decoder, NoEncoder
 
 def make_enc_dec(fb_name, mask_mode='reim', inp_mode='reim',
                  who_is_pinv=None, **kwargs):
-    """
-    Creates congruent encoder and decoder from the same filterbank family.
+    """ Creates congruent encoder and decoder from the same filterbank family.
+
     Args:
-        fb_name: String or className. Filterbank family from which to make
-            encoder and decoder. Among [`'free'`, `'analytic_free'`,
-            `'param_sinc'`, `'stft'`] and many more to come. ClassName such
-            as `FreeFB` and such.
-        inp_mode: String. One of [`'reim'`, `'mag'`, `'cat'`]. Controls
-            `post_processing_inputs` method which can be applied after
-            the forward.
-            - `'reim'` or `'real'` corresponds to the concatenation of
-                real and imaginary parts. (filterbank seen as real-valued).
-            - `'mag'` or `'mod'`corresponds to the magnitude (or modulus)of the
-                complex filterbank output.
-            - `'cat'` or `'concat'` corresponds to the concatenation of both
-                previous representations.
-        mask_mode: String. One of [`'reim'`, `'mag'`, `'comp'`]. Controls
-            the way the time-frequency mask is applied to the input
+        fb_name (str, className): Filterbank family from which to make encoder
+            and decoder. To choose from among [``'free'``, ``'analytic_free'``,
+            ``'param_sinc'``, ``'stft'``] and many more to come. Can also be
+            a class defined in a submodule in this subpackade (e.g.
+            :class:`~.FreeFB`).
+        mask_mode (str, optional): One of [``'reim'``, ``'mag'``, ``'comp'``].
+            Controls the way the time-frequency mask is applied to the input
             representation in the `apply_mask` method.
-            - `'reim'` or `'real'` corresponds to a real-valued filterbank
-                where both the input and the mask consists in the
-                concatenation of real and imaginary parts.
-            - `'mag'` or `'mod'`corresponds to a magnitude (or modulus) mask
-                applied to the complex filterbank output.
-            - `'comp'` or `'complex'` corresponds to a complex mask : the
-                input and the mask are point-wise multiplied in the complex
-                sense.
-        who_is_pinv: None or String. If None, no pseudo-inverse filters will be
-            used. If string, among `'encoder'`, `'decoder'`, decides which of
-            `Encoder` or `Decoder` will be the pseudo inverse of the other one.
+                -  ``'reim'`` or ``'real'`` corresponds to a real-valued
+                   filterbank where both the input and the mask consists in the
+                   concatenation of real and imaginary parts.
+                -  ``'mag'`` or ``'mod'`` corresponds to a magnitude (or
+                   modulus) mask applied to the complex filterbank output.
+                -  ``'comp'`` or ``'complex'`` corresponds to a complex mask:
+                   the input and the mask are point-wise multiplied in the
+                   complex sense.
+        inp_mode (str, optional): One of [``'reim'``, ``'mag'``, ``'cat'``].
+            Controls `post_processing_inputs` method which can be applied after
+            the forward.
+                -  ``'reim'`` or ``'real'`` corresponds to the concatenation
+                   of real and imaginary parts. (filterbank seen as
+                   real-valued).
+                -  ``'mag'`` or ``'mod'`` corresponds to the magnitude (or
+                   modulus)
+                   of the complex filterbank output.
+                -  ``'cat'`` or ``'concat'`` corresponds to the concatenation
+                   of both previous representations.
+        who_is_pinv (str, optional): If None, no pseudo-inverse filters will be
+            used. If string, among ``'encoder'``, ``'decoder'``, decides which
+            of ``Encoder`` or ``Decoder`` will be the pseudo inverse of the
+            other one.
         **kwargs: Arguments which will be passed to the filterbank class.
             Usual argument include `n_filters`, `kernel_size` and `stride` but
             this will depend on the filterbank family.

--- a/asteroid/filterbanks/analytic_free_fb.py
+++ b/asteroid/filterbanks/analytic_free_fb.py
@@ -1,6 +1,6 @@
 """
-Analytic free filterbank.
-@author : Manuel Pariente, Inria-Nancy
+| Analytic free filterbank.
+| @author : Manuel Pariente, Inria-Nancy
 """
 
 import torch
@@ -11,20 +11,21 @@ from .enc_dec import Filterbank
 
 
 class AnalyticFreeFB(Filterbank):
-    """Free analytic (fully learned with analycity constraints) filterbank
-        proposed in [1].
+    """ Free analytic (fully learned with analycity constraints) filterbank
 
-    # Args
-        n_filters: Positive int. Number of filters. Half of `n_filters` will
+        For more details, see [1].
+
+    Args:
+        n_filters (int): Number of filters. Half of `n_filters` will
             have parameters, the other half will be the hilbert transforms.
             `n_filters` should be even.
-        kernel_size: Positive int. Length of the filters.
-        stride: Positive int. Stride of the convolution.
-            If None (default), set to `kernel_size // 2`.
-        enc_or_dec: String. `enc` or `dec`. Controls if filterbank is used as
-            an encoder or a decoder.
+        kernel_size (int): Length of the filters.
+        stride (int, optional): Stride of the convolution.
+            If None (default), set to ``kernel_size // 2``.
+        enc_or_dec (str): ``'enc'`` or ``'dec'``. Controls if filterbank is
+            used as an encoder or a decoder.  ``unused in init?``
 
-    # References
+    References:
         [1] : "Filterbank design for end-to-end speech separation".
         Submitted to ICASSP 2020. Manuel Pariente, Samuele Cornell,
         Antoine Deleforge, Emmanuel Vincent.

--- a/asteroid/filterbanks/analytic_free_fb.py
+++ b/asteroid/filterbanks/analytic_free_fb.py
@@ -22,8 +22,6 @@ class AnalyticFreeFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
-        enc_or_dec (str): ``'enc'`` or ``'dec'``. Controls if filterbank is
-            used as an encoder or a decoder.  ``unused in init?``
 
     References:
         [1] : "Filterbank design for end-to-end speech separation".

--- a/asteroid/filterbanks/enc_dec.py
+++ b/asteroid/filterbanks/enc_dec.py
@@ -18,7 +18,7 @@ class Filterbank(nn.Module):
     Args:
         n_filters (int): Number of filters.
         kernel_size (int): Length of the filters.
-        stride (int): Stride of the conv or transposed conv. (Hop size).
+        stride (int, optional): Stride of the conv or transposed conv. (Hop size).
             If None (default), set to ``kernel_size // 2``.
 
     Attributes:

--- a/asteroid/filterbanks/enc_dec.py
+++ b/asteroid/filterbanks/enc_dec.py
@@ -1,6 +1,6 @@
 """
-Base classes for filterbanks, encoders and decoders.
-@author : Manuel Pariente, Inria-Nancy
+| Base classes for filterbanks, encoders and decoders.
+| @author : Manuel Pariente, Inria-Nancy
 """
 
 import torch
@@ -12,13 +12,19 @@ from . inputs_and_masks import _inputs, _masks
 
 class Filterbank(nn.Module):
     """Base Filterbank class.
+
     Each subclass has to implement a `filters` property.
 
-    # Args
-        n_filters: Positive int. Number of filters.
-        kernel_size: Positive int. Length of the filters.
-        stride: Positive int. Stride of the conv or transposed conv. (Hop size).
-            If None (default), set to `kernel_size // 2`.
+    Args:
+        n_filters (int): Number of filters.
+        kernel_size (int): Length of the filters.
+        stride (int): Stride of the conv or transposed conv. (Hop size).
+            If None (default), set to ``kernel_size // 2``.
+
+    Attributes:
+        n_filters (int)
+        kernel_size (int)
+        stride (int)
     """
     def __init__(self, n_filters, kernel_size, stride=None):
         super(Filterbank, self).__init__()
@@ -32,7 +38,7 @@ class Filterbank(nn.Module):
         raise NotImplementedError
 
     def get_config(self):
-        """ Returns dictionary of arguments to re-instantiate the class."""
+        """ Returns dictionary of arguments to re-instantiate the class. """
         config = {
             'n_filters': self.n_filters,
             'kernel_size': self.kernel_size,
@@ -43,11 +49,18 @@ class Filterbank(nn.Module):
 
 class _EncDec(nn.Module):
     """ Base private class for Encoder and Decoder.
+
     Common parameters and methods.
+
     Args:
-        filterbank: (subclass of) Filterbank instance. The filterbank to
-            use as an encoder or a decoder.
-        is_pinv: Bool. Whether to be the pseudo inverse of filterbank.
+        filterbank (:class:`Filterbank`): Filterbank instance. The filterbank
+            to use as an encoder or a decoder.
+        is_pinv (bool): Whether to be the pseudo inverse of filterbank.
+
+    Attributes:
+        filterbank (:class:`Filterbank`)
+        stride (int)
+        is_pinv (bool)
     """
     def __init__(self, filterbank, is_pinv=False):
         super(_EncDec, self).__init__()
@@ -80,33 +93,43 @@ class _EncDec(nn.Module):
 
 
 class Encoder(_EncDec):
-    """ Encoder class. Add encoding methods to Filterbank classes.
+    """ Encoder class.
+
+    Add encoding methods to Filterbank classes.
     Not intended to be subclassed.
 
     Args:
-        filterbank: (subclass of) Filterbank instance. The filterbank to use
+        filterbank (:class:`Filterbank`): The filterbank to use
             as an encoder.
-        is_pinv: Bool. Whether to be the pseudo inverse of filterbank.
-        inp_mode: String. One of [`'reim'`, `'mag'`, `'cat'`]. Controls
+        is_pinv (bool): Whether to be the pseudo inverse of filterbank.
+        inp_mode (str): One of [``'reim'``, ``'mag'``, ``'cat'``]. Controls
             `post_processing_inputs` method which can be applied after
             the forward.
-            - `'reim'` or `'real'` corresponds to the concatenation of
-                real and imaginary parts. (filterbank seen as real-valued).
-            - `'mag'` or `'mod'`corresponds to the magnitude (or modulus)of the
-                complex filterbank output.
-            - `'cat'` or `'concat'` corresponds to the concatenation of both
-                previous representations.
-        mask_mode: String. One of [`'reim'`, `'mag'`, `'comp'`]. Controls
+                -  ``'reim'`` or ``'real'`` corresponds to the concatenation of
+                   real and imaginary parts. (filterbank seen as real-valued).
+                -  ``'mag'`` or ``'mod'`` corresponds to the magnitude (or
+                   modulus) of the complex filterbank output.
+                -  ``'cat'`` or ``'concat'`` corresponds to the concatenation of
+                   both previous representations.
+        mask_mode (str): One of [``'reim'``, ``'mag'``, ``'comp'``]. Controls
             the way the time-frequency mask is applied to the input
-            representation in the `apply_mask` method.
-            - `'reim'` or `'real'` corresponds to a real-valued filterbank
-                where both the input and the mask consists in the
-                concatenation of real and imaginary parts.
-            - `'mag'` or `'mod'`corresponds to a magnitude (or modulus) mask
-                applied to the complex filterbank output.
-            - `'comp'` or `'complex'` corresponds to a complex mask : the
-                input and the mask are point-wise multiplied in the complex
-                sense.
+            representation in the :func:`apply_mask` method.
+                -  ``'reim'`` or ``'real'`` corresponds to a real-valued
+                   filterbank where both the input and the mask consists in the
+                   concatenation of real and imaginary parts.
+                -  ``'mag'`` or ``'mod'`` corresponds to a magnitude (or
+                   modulus) mask applied to the complex filterbank output.
+                -  ``'comp'`` or ``'complex'`` corresponds to a complex mask:
+                   the input and the mask are point-wise multiplied in the
+                   complex sense.
+
+    Attributes:
+        inp_mode (str)
+        mask_mode (str)
+        inp_func (callable)
+        in_chan_mul
+        mask_fun (callable)
+        n_feats_out (int)
     """
     def __init__(self, filterbank, inp_mode='reim', mask_mode='reim',
                  is_pinv=False):
@@ -150,12 +173,14 @@ class Encoder(_EncDec):
 
 
 class Decoder(_EncDec):
-    """Decoder class. Add decoding methods to Filterbank classes.
+    """Decoder class.
+    
+    Add decoding methods to Filterbank classes.
     Not intended to be subclassed.
+
     Args:
-        filterbank: (subclass of) Filterbank instance. The filterbank to use
-            as an decoder.
-        is_pinv: Bool. Whether to be the pseudo inverse of filterbank.
+        filterbank (:class:`Filterbank`): The filterbank to use as an decoder.
+        is_pinv (bool): Whether to be the pseudo inverse of filterbank.
     """
     @classmethod
     def pinv_of(cls, filterbank):
@@ -166,14 +191,15 @@ class Decoder(_EncDec):
             return cls(filterbank.filterbank, is_pinv=True)
 
     def forward(self, spec):
-        """
-        Applies transposed convolution to a TF representation. This is
-        equivalent to overlap-add.
+        """ Applies transposed convolution to a TF representation.
+
+        This is equivalent to overlap-add.
+
         Args:
-            spec: 3D or 4D torch.Tensor. The TF representation.
-                (Output of `Encoder.forward`).
+            spec (:class:`torch.Tensor`): 3D or 4D Tensor. The TF
+                representation. (Output of :func:`Encoder.forward`).
         Returns:
-            torch.Tensor, the corresponding time domain signal.
+            :class:`torch.Tensor`: The corresponding time domain signal.
         """
         filters = self.get_filters()
 
@@ -187,37 +213,39 @@ class Decoder(_EncDec):
 
 
 class NoEncoder(nn.Module):
-    """ Class to use for no neural encoder, i.e this is a placeholder for
-    precomputed features.
+    """ Class to use for no neural encoder.
+    
+    This is a placeholder for precomputed features.
     The features can be complex with real and imaginary parts concatenated
     into the same axis. The same post processing and masking strategies are
-    available as for the `Encoder` class.
+    available as for the :class:`Encoder` class.
 
     Args:
-        inp_mode: String. One of [`'reim'`, `'mag'`, `'cat'`]. Controls
+        inp_mode (str): One of [``'reim'``, ``'mag'``, ``'cat'``]. Controls
             `post_processing_inputs` method which can be applied after
             the forward.
-            - `'reim'` or `'real'` corresponds to the concatenation of
-                real and imaginary parts. (filterbank seen as real-valued).
-            - `'mag'` or `'mod'`corresponds to the magnitude (or modulus)of the
-                complex filterbank output.
-            - `'cat'` or `'concat'` corresponds to the concatenation of both
-                previous representations.
-        mask_mode: String. One of [`'reim'`, `'mag'`, `'comp'`]. Controls
+                -  ``'reim'`` or ``'real'`` corresponds to the concatenation of
+                   real and imaginary parts. (filterbank seen as real-valued).
+                -  ``'mag'`` or ``'mod'`` corresponds to the magnitude (or
+                   modulus) of the complex filterbank output.
+                -  ``'cat'`` or ``'concat'`` corresponds to the concatenation
+                   of both previous representations.
+        mask_mode (str): One of [``'reim'``, ``'mag'``, ``'comp'``]. Controls
             the way the time-frequency mask is applied to the input
-            representation in the `apply_mask` method.
-            - `'reim'` or `'real'` corresponds to a real-valued filterbank
-                where both the input and the mask consists in the
-                concatenation of real and imaginary parts.
-            - `'mag'` or `'mod'`corresponds to a magnitude (or modulus) mask
-                applied to the complex filterbank output.
-            - `'comp'` or `'complex'` corresponds to a complex mask : the
-                input and the mask are point-wise multiplied in the complex
-                sense.
-    By default :
-     - The forward returns the input.
-     - The input post-processing is the identity.
-     - The mask is applied to the input features.
+            representation in the :func:`apply_mask` method.
+                -  ``'reim'`` or ``'real'`` corresponds to a real-valued
+                   filterbank where both the input and the mask consists in the
+                   concatenation of real and imaginary parts.
+                -  ``'mag'`` or ``'mod'`` corresponds to a magnitude (or
+                   modulus) mask applied to the complex filterbank output.
+                -  ``'comp'`` or ``'complex'`` corresponds to a complex mask:
+                   the input and the mask are point-wise multiplied in the
+                   complex sense.
+
+    By default:
+        - The forward returns the input.
+        - The input post-processing is the identity.
+        - The mask is applied to the input features.
     """
     def __init__(self, inp_mode='reim', mask_mode='reim'):
 

--- a/asteroid/filterbanks/free_fb.py
+++ b/asteroid/filterbanks/free_fb.py
@@ -18,8 +18,6 @@ class FreeFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution.
             If None (default), set to ``kernel_size // 2``.
-        enc_or_dec (str, optional): ``'enc'`` or ``'dec'``. Controls if
-            filterbank is used as an encoder or a decoder. ``unused``
 
     Attributes:
         n_feats_out (int): Number of filters.

--- a/asteroid/filterbanks/free_fb.py
+++ b/asteroid/filterbanks/free_fb.py
@@ -1,6 +1,6 @@
 """
-Free filterbank.
-@author : Manuel Pariente, Inria-Nancy
+| Free filterbank.
+| @author : Manuel Pariente, Inria-Nancy
 """
 
 import torch
@@ -9,17 +9,22 @@ from .enc_dec import Filterbank
 
 
 class FreeFB(Filterbank):
-    """Free filterbank without any constraints. Equivalent to nn.Conv1d.
+    """Free filterbank without any constraints.
 
-    # Args
-        n_filters: Positive int. Number of filters.
-        kernel_size: Positive int. Length of the filters.
-        stride: Positive int. Stride of the convolution.
-            If None (default), set to `kernel_size // 2`.
-        enc_or_dec: String. `enc` or `dec`. Controls if filterbank is used as
-            an encoder or a decoder.
+    Equivalent to nn.Conv1d.
 
-    # References
+    Args:
+        n_filters (int): Number of filters.
+        kernel_size (int): Length of the filters.
+        stride (int, optional): Stride of the convolution.
+            If None (default), set to ``kernel_size // 2``.
+        enc_or_dec (str, optional): ``'enc'`` or ``'dec'``. Controls if
+            filterbank is used as an encoder or a decoder. ``unused``
+
+    Attributes:
+        n_feats_out (int): Number of filters.
+
+    References:
         [1] : "Filterbank design for end-to-end speech separation".
         Submitted to ICASSP 2020. Manuel Pariente, Samuele Cornell,
         Antoine Deleforge, Emmanuel Vincent.

--- a/asteroid/filterbanks/inputs_and_masks.py
+++ b/asteroid/filterbanks/inputs_and_masks.py
@@ -61,8 +61,6 @@ def take_reim(x, dim=1):
 def take_mag(x, dim=1):
     """ Takes the magnitude of a complex tensor.
 
-    **Shouldn't this be called the power?**
-
     The operands is assumed to have the real parts of each entry followed by
     the imaginary parts of each entry along dimension `dim`, e.g. for,
     ``dim = 1``, the matrix
@@ -88,7 +86,8 @@ def take_mag(x, dim=1):
     Returns:
         :class:`torch.Tensor`: The magnitude of x.
     """
-    return torch.stack(torch.chunk(x, 2, dim=dim), dim=-1).pow(2).sum(dim=-1)
+    return torch.stack(torch.chunk(x, 2, dim=dim),
+                       dim=-1).pow(2).sum(dim=-1).pow(0.5)
 
 
 def take_cat(x, dim=1):

--- a/asteroid/filterbanks/param_sinc_fb.py
+++ b/asteroid/filterbanks/param_sinc_fb.py
@@ -1,10 +1,10 @@
 """
-Sinc-based parameterized filterbank.
-@author : Manuel Pariente, Inria-Nancy
+| Sinc-based parameterized filterbank.
+| @author : Manuel Pariente, Inria-Nancy
 
-Modified and extended from from https://github.com/mravanelli/SincNet
-Copyright (c) 2019 Mirco Ravanelli
-See also https://github.com/mravanelli/SincNet/blob/master/LICENSE
+| Modified and extended from from https://github.com/mravanelli/SincNet
+| Copyright (c) 2019 Mirco Ravanelli
+| See also https://github.com/mravanelli/SincNet/blob/master/LICENSE
 """
 
 import numpy as np
@@ -17,23 +17,31 @@ from .enc_dec import Filterbank
 class ParamSincFB(Filterbank):
     """Extension of the parameterized filterbank from [1] proposed in [2].
 
-    # Args
-        n_filters: Positive int. Number of filters. Half of `n_filters`
-            (the real parts) will have parameters, the other half will
-            correspond to the imaginary parts.
-            `n_filters` should be even.
-        kernel_size: Positive int. Length of the filters.
-        stride: Positive int. Stride of the convolution.
-            If None (default), set to `kernel_size // 2`.
-        enc_or_dec: String. `enc` or `dec`. Controls if filterbank is used as
-            an encoder or a decoder.
-        sample_rate: int. The sample rate (used for initialization).
-        min_low_hz: Positive int. Lowest low frequency allowed (Hz).
-        min_band_hz: Positive int. Lowest band frequency allowed (Hz).
+    Args:
+        n_filters (int): Number of filters. Half of `n_filters` (the real
+            parts) will have parameters, the other half will correspond to the
+            imaginary parts. `n_filters` should be even.
+        kernel_size (int): Length of the filters.
+        stride (int, optional): Stride of the convolution. If None (default),
+            set to ``kernel_size // 2``.
+        enc_or_dec (str, optional): ``'enc'`` or ``'dec'``. Controls if
+            filterbank is used as an encoder or a decoder.
+        sample_rate (int, optional): The sample rate (used for initialization).
+        min_low_hz (int, optional): Lowest low frequency allowed (Hz).
+        min_band_hz (int, optional): Lowest band frequency allowed (Hz).
 
-    # References
+    Attributes:
+        sample_rate (int)
+        min_low_hz (int)
+        min_band_hz (int)
+        half_kernel (int)
+        cutoff (int)
+        n_feats_out (int)
+
+    References:
         [1] : "Speaker Recognition from raw waveform with SincNet". SLT 2018.
         Mirco Ravanelli, Yoshua Bengio.  https://arxiv.org/abs/1808.00158
+
         [2] : "Filterbank design for end-to-end speech separation".
         Submitted to ICASSP 2020. Manuel Pariente, Samuele Cornell,
         Antoine Deleforge, Emmanuel Vincent.

--- a/asteroid/filterbanks/param_sinc_fb.py
+++ b/asteroid/filterbanks/param_sinc_fb.py
@@ -2,9 +2,9 @@
 | Sinc-based parameterized filterbank.
 | @author : Manuel Pariente, Inria-Nancy
 
-| Modified and extended from from https://github.com/mravanelli/SincNet
+| Modified and extended from from `<https://github.com/mravanelli/SincNet>`__
 | Copyright (c) 2019 Mirco Ravanelli
-| See also https://github.com/mravanelli/SincNet/blob/master/LICENSE
+| See also `<https://github.com/mravanelli/SincNet/blob/master/LICENSE>`__
 """
 
 import numpy as np

--- a/asteroid/filterbanks/param_sinc_fb.py
+++ b/asteroid/filterbanks/param_sinc_fb.py
@@ -24,8 +24,6 @@ class ParamSincFB(Filterbank):
         kernel_size (int): Length of the filters.
         stride (int, optional): Stride of the convolution. If None (default),
             set to ``kernel_size // 2``.
-        enc_or_dec (str, optional): ``'enc'`` or ``'dec'``. Controls if
-            filterbank is used as an encoder or a decoder.
         sample_rate (int, optional): The sample rate (used for initialization).
         min_low_hz (int, optional): Lowest low frequency allowed (Hz).
         min_band_hz (int, optional): Lowest band frequency allowed (Hz).

--- a/asteroid/filterbanks/stft_fb.py
+++ b/asteroid/filterbanks/stft_fb.py
@@ -18,8 +18,6 @@ class STFTFB(Filterbank):
             (default), set to ``kernel_size // 2``.
         window (:class:`numpy.ndarray`, optional): If None, defaults to
             ``np.sqrt(np.hanning())``.
-        enc_or_dec (str, optional): Either ``'enc'`` or ``'dec'``. Controls if
-            filterbank is used as an encoder or a decoder.
     """
     def __init__(self, n_filters, kernel_size, stride=None, window=None,
                  **kwargs):

--- a/asteroid/filterbanks/stft_fb.py
+++ b/asteroid/filterbanks/stft_fb.py
@@ -1,6 +1,6 @@
 """
-STFT filterbank i.e DFT filters
-@author : Manuel Pariente, Inria-Nancy
+| STFT filterbank i.e DFT filters
+| @author : Manuel Pariente, Inria-Nancy
 """
 import torch
 import numpy as np
@@ -10,16 +10,16 @@ from .enc_dec import Filterbank
 class STFTFB(Filterbank):
     """STFT filterbank.
 
-    # Args
-        n_filters: Positive int. Number of filters. Determines the length
-            of the STFT filters before windowing.
-        kernel_size: Positive int. Length of the filters (i.e the window).
-        stride: Positive int. Stride of the convolution (hop size).
-            If None (default), set to `kernel_size // 2`.
-        window: None or numpy array. If None, defaults to
-            `np.sqrt(np.hanning())`.
-        enc_or_dec: String. `enc` or `dec`. Controls if filterbank is used
-            as an encoder or a decoder.
+    Args:
+        n_filters (int): Number of filters. Determines the length of the STFT
+            filters before windowing.
+        kernel_size (int): Length of the filters (i.e the window).
+        stride (int, optional): Stride of the convolution (hop size). If None
+            (default), set to ``kernel_size // 2``.
+        window (:class:`numpy.ndarray`, optional): If None, defaults to
+            ``np.sqrt(np.hanning())``.
+        enc_or_dec (str, optional): Either ``'enc'`` or ``'dec'``. Controls if
+            filterbank is used as an encoder or a decoder.
     """
     def __init__(self, n_filters, kernel_size, stride=None, window=None,
                  **kwargs):

--- a/asteroid/masknn/activations.py
+++ b/asteroid/masknn/activations.py
@@ -1,6 +1,6 @@
 """
-Activation functions which are retrievable from a string (all lower-case).
-@author : Manuel Pariente, Inria-Nancy
+| Activation functions which are retrievable from a string (all lower-case).
+| @author : Manuel Pariente, Inria-Nancy
 """
 
 from torch import nn

--- a/asteroid/masknn/blocks.py
+++ b/asteroid/masknn/blocks.py
@@ -165,8 +165,8 @@ class SingleRNN(nn.Module):
         hidden_size (int): Dimension of the hidden state.
         n_layers (int, optional): Number of layers used in RNN. Default is 1.
         dropout (float, optional): Dropout ratio. Default is 0.
-        bidirectional (bool): Whether the RNN layers are bidirectional.
-            Default is ``False``.
+        bidirectional (bool, optional): Whether the RNN layers are 
+            bidirectional. Default is ``False``.
     """
 
     def __init__(self, rnn_type, input_size, hidden_size, n_layers=1,

--- a/asteroid/masknn/blocks.py
+++ b/asteroid/masknn/blocks.py
@@ -1,6 +1,6 @@
 """
-NN blocks for separators.
-@author : Manuel Pariente, Inria-Nancy
+| NN blocks for separators.
+| @author : Manuel Pariente, Inria-Nancy
 """
 
 from torch import nn
@@ -13,21 +13,24 @@ from ..utils import has_arg
 class Conv1DBlock(nn.Module):
     """One dimensional convolutional block, as proposed in [1].
 
-    Args
-        in_chan: int. Number of input channels.
-        hid_chan: int. Number of hidden channels in the depth-wise convolution.
-        skip_out_chan: int. Number of channels in the skip convolution.
-        kernel_size: int. Size of the depth-wise convolutional kernel.
-        padding: int. Padding of the depth-wise convolution.
-        dilation: int. Dilation of the depth-wise convolution.
-        norm_type: string. Type of normalization to use.
-            Among `gLN` (global Layernorm), `cLN` (channelwise Layernorm) and
-            `cgLN` (cumulative global Layernorm).
+    Args:
+        in_chan (int): Number of input channels.
+        hid_chan (int): Number of hidden channels in the depth-wise
+            convolution.
+        skip_out_chan (int): Number of channels in the skip convolution.
+        kernel_size (int): Size of the depth-wise convolutional kernel.
+        padding (int): Padding of the depth-wise convolution.
+        dilation (int): Dilation of the depth-wise convolution.
+        norm_type (str, optional): Type of normalization to use. To choose from
 
-    References :
-    [1] : "Conv-TasNet: Surpassing ideal time-frequency magnitude masking for
-    speech separation" TASLP 2019 Yi Luo, Nima Mesgarani
-    https://arxiv.org/abs/1809.07454
+            -  ``'gLN'``: global Layernorm
+            -  ``'cLN'``: channelwise Layernorm
+            -  ``'cgLN'``: cumulative global Layernorm
+
+    References:
+        [1] : "Conv-TasNet: Surpassing ideal time-frequency magnitude masking
+        for speech separation" TASLP 2019 Yi Luo, Nima Mesgarani
+        https://arxiv.org/abs/1809.07454
     """
     def __init__(self, in_chan, hid_chan, skip_out_chan, kernel_size, padding,
                  dilation, norm_type="gLN"):
@@ -54,20 +57,22 @@ class Conv1DBlock(nn.Module):
 class TDConvNet(nn.Module):
     """ Temporal Convolutional network used in ConvTasnet.
 
-    Args
-        in_chan: int > 0. Number of input filters.
-        n_src: int > 0. Number of masks to estimate.
-        out_chan : int > 0. Number of bins in the estimated masks.
-            If None, `out_chan = in_chan`.
-        n_blocks: int > 0. Number of convolutional blocks in each repeat.
-            Defaults to 8
-        n_repeats: int > 0. Number of repeats. Defaults to 3.
-        bn_chan: int > 0. Number of channels after the bottleneck.
-        hid_chan: int > 0. Number of channels in the convolutional blocks.
-        skip_chan: int > 0. Number of channels in the skip connections.
-        kernel_size: int > 0. Kernel size in convolutional blocks.
-        norm_type: string. Among [BN, gLN, cLN]
-        mask_act: string. Which non-linear function to generate mask
+    Args:
+        in_chan (int): Number of input filters.
+        n_src (int): Number of masks to estimate.
+        out_chan (int, optional): Number of bins in the estimated masks.
+            If ``None``, `out_chan = in_chan`.
+        n_blocks (int, optional): Number of convolutional blocks in each
+            repeat. Defaults to 8.
+        n_repeats (int, optional): Number of repeats. Defaults to 3.
+        bn_chan (int, optional): Number of channels after the bottleneck.
+        hid_chan (int, optional): Number of channels in the convolutional
+            blocks.
+        skip_chan (int, optional): Number of channels in the skip connections.
+        kernel_size (int, optional): Kernel size in convolutional blocks.
+        norm_type (str, optional): To choose from ``'BN'``, ``'gLN'``,
+            ``'cLN'``.
+        mask_act (str, optional): Which non-linear function to generate mask.
     """
     def __init__(self, in_chan, n_src, out_chan=None, n_blocks=8, n_repeats=3,
                  bn_chan=128, hid_chan=512, skip_chan=128, kernel_size=3,
@@ -108,10 +113,14 @@ class TDConvNet(nn.Module):
 
     def forward(self, mixture_w):
         """
+
         Args:
-            mixture_w: torch.Tensor of shape [batch, n_filters, n_frames]
+            mixture_w (:class:`torch.Tensor`): Tensor of shape
+                [batch, n_filters, n_frames]
+
         Returns:
-            est_mask: torch.Tensor of shape [batch, n_src, n_filters, n_frames]
+            :class:`torch.Tensor`:
+                estimated mask of shape [batch, n_src, n_filters, n_frames]
         """
         batch, n_filters, n_frames = mixture_w.size()
         output = self.bottleneck(mixture_w)
@@ -145,19 +154,19 @@ class TDConvNet(nn.Module):
 class SingleRNN(nn.Module):
     """ Module for a RNN block.
 
-    Inspired from github.com/yluo42/TAC/blob/master/utility/models.py
+    Inspired from https://github.com/yluo42/TAC/blob/master/utility/models.py
     Licensed under CC BY-NC-SA 3.0 US.
 
     Args:
-        rnn_type: string, select from `'RNN'`, `'LSTM'`, `'GRU'`. Can
+        rnn_type (str): Select from ``'RNN'``, ``'LSTM'``, ``'GRU'``. Can
             also be passed in lowercase letters.
-        input_size: int, dimension of the input feature. The input should have
-            shape (batch, seq_len, input_size).
-        hidden_size: int, dimension of the hidden state.
-        dropout: float, dropout ratio. Default is 0.
-        n_layers: int > 0. Number of layers used in RNN. Default is 1.
-        bidirectional: bool, whether the RNN layers are bidirectional.
-            Default is False.
+        input_size (int): Dimension of the input feature. The input should have
+            shape [batch, seq_len, input_size].
+        hidden_size (int): Dimension of the hidden state.
+        n_layers (int, optional): Number of layers used in RNN. Default is 1.
+        dropout (float, optional): Dropout ratio. Default is 0.
+        bidirectional (bool): Whether the RNN layers are bidirectional.
+            Default is ``False``.
     """
 
     def __init__(self, rnn_type, input_size, hidden_size, n_layers=1,
@@ -181,23 +190,24 @@ class SingleRNN(nn.Module):
 
 
 class DPRNNBlock(nn.Module):
-    """Dual-Path RNN Block as proposed in [1].
+    """ Dual-Path RNN Block as proposed in [1].
 
-    Args
-        in_chan: int. Number of input channels.
-        hid_size: int. Number of hidden neurons in the RNNs.
-        norm_type: string. Type of normalization to use.
-            Among `gLN` (global Layernorm), `cLN` (channelwise Layernorm).
-        bidirectional: bool. True for bidirectional Inter-Chunk RNN.
-        rnn_type: string. Type of RNN used.
-            Choose between 'RNN', 'LSTM' and 'GRU'.
-        num_layers: int>0. Number of layers used in each RNN.
-        dropout: int in (0,1).
+    Args:
+        in_chan (int): Number of input channels.
+        hid_size (int): Number of hidden neurons in the RNNs.
+        norm_type (str, optional): Type of normalization to use. To choose from
+            - ``'gLN'``: global Layernorm
+            - ``'cLN'``: channelwise Layernorm
+        bidirectional (bool, optional): True for bidirectional Inter-Chunk RNN.
+        rnn_type (str, optional): Type of RNN used. Choose from ``'RNN'``,
+            ``'LSTM'`` and ``'GRU'``.
+        num_layers (int, optional): Number of layers used in each RNN.
+        dropout (float, optional): Dropout ratio. Must be in [0, 1].
 
-    References :
-        [1] : "Dual-path RNN: efficient long sequence modeling for
-            time-domain single-channel speech separation", Yi Luo, Zhuo Chen
-            and Takuya Yoshioka. https://arxiv.org/abs/1910.06379
+    References:
+        [1] "Dual-path RNN: efficient long sequence modeling for
+        time-domain single-channel speech separation", Yi Luo, Zhuo Chen
+        and Takuya Yoshioka. https://arxiv.org/abs/1910.06379
     """
     def __init__(self, in_chan, hid_size, norm_type="gLN", bidirectional=True,
                  rnn_type="LSTM", num_layers=1, dropout=0):
@@ -215,7 +225,7 @@ class DPRNNBlock(nn.Module):
         self.inter_norm = norms.get(norm_type)(in_chan)
 
     def forward(self, x):
-        """ Input shape : [batch, feats, chunk_size, num_chunks]"""
+        """ Input shape : [batch, feats, chunk_size, num_chunks] """
         B, N, K, L = x.size()
         output = x  # for skip connection
         # Intra-chunk processing
@@ -236,30 +246,34 @@ class DPRNNBlock(nn.Module):
 
 class DPRNN(nn.Module):
     """ Dual-path RNN Network for Single-Channel Source Separation
-        introduced in [1].
-    Args
-        in_chan: int > 0. Number of input filters.
-        out_chan : int > 0. Number of bins in the estimated masks.
-        bn_chan: int > 0. Number of channels after the bottleneck.
-        hid_size: int > 0. Number of neurons in the RNNs cell state.
-        chunk_size: int > 0. window size of overlap and add processing.
-        hop_size: int > 0. hop size (stride) of overlap and add processing.
-        n_repeats: int > 0. Number of repeats.
-        n_src: int > 0. Number of masks to estimate.
-        norm_type: string. Type of normalization to use.
-            Among `gLN` (global Layernorm), `cLN` (channelwise Layernorm).
-        mask_act: string. Which non-linear function to generate mask.
-        bidirectional: bool: True for bidirectional Inter-Chunk RNN
-            (Intra-Chunk is always bidirectional).
-        rnn_type: string. Type of RNN used. Choose between 'RNN',
-            'LSTM' and 'GRU'.
-        num_layers: number of layers in each RNN.
-        dropout: int in (0,1).
 
-    References :
-        [1] : "Dual-path RNN: efficient long sequence modeling for
-            time-domain single-channel speech separation", Yi Luo, Zhuo Chen
-            and Takuya Yoshioka. https://arxiv.org/abs/1910.06379
+        Method introduced in [1].
+
+    Args:
+        in_chan (int): Number of input filters.
+        out_chan  (int): Number of bins in the estimated masks.
+        bn_chan (int): Number of channels after the bottleneck.
+        hid_size (int): Number of neurons in the RNNs cell state.
+        chunk_size (int): window size of overlap and add processing.
+        hop_size (int): hop size (stride) of overlap and add processing.
+        n_repeats (int): Number of repeats.
+        n_src (int): Number of masks to estimate.
+        norm_type (str, optional): Type of normalization to use. To choose from
+
+            - ``'gLN'``: global Layernorm
+            - ``'cLN'``: channelwise Layernorm
+        mask_act (str, optional): Which non-linear function to generate mask.
+        bidirectional (bool, optional): True for bidirectional Inter-Chunk RNN
+            (Intra-Chunk is always bidirectional).
+        rnn_type (str, optional): Type of RNN used. Choose between ``'RNN'``,
+            ``'LSTM'`` and ``'GRU'``.
+        num_layers (int, optional): Number of layers in each RNN.
+        dropout (float, optional): Dropout ratio, must be in [0,1].
+
+    References:
+        [1] "Dual-path RNN: efficient long sequence modeling for
+        time-domain single-channel speech separation", Yi Luo, Zhuo Chen
+        and Takuya Yoshioka. https://arxiv.org/abs/1910.06379
     """
     def __init__(self, in_chan, out_chan, bn_chan, hid_size, chunk_size,
                  hop_size, n_repeats, n_src, norm_type="gLN",
@@ -306,9 +320,11 @@ class DPRNN(nn.Module):
     def forward(self, mixture_w):
         """
         Args:
-            mixture_w: torch.Tensor of shape [batch, n_filters, n_frames]
+            mixture_w (:class:`torch.Tensor`): Tensor of shape
+                [batch, n_filters, n_frames]
         Returns:
-            est_mask: torch.Tensor of shape [batch, n_src, n_filters, n_frames]
+            :class:`torch.Tensor`
+                estimated mask of shape [batch, n_src, n_filters, n_frames]
         """
         batch, n_filters, n_frames = mixture_w.size()
         output = self.bottleneck(mixture_w)  # [batch, bn_chan, n_frames]

--- a/asteroid/masknn/norms.py
+++ b/asteroid/masknn/norms.py
@@ -1,6 +1,6 @@
 """
-Normalization classes.
-@author : Manuel Pariente, Inria-Nancy
+| Normalization classes.
+| @author : Manuel Pariente, Inria-Nancy
 """
 
 import torch
@@ -19,7 +19,7 @@ class _LayerNorm(nn.Module):
                                  requires_grad=True)
 
     def apply_gain_and_bias(self, normed_x):
-        """ Assumes input of size [batch, chanel, *]. """
+        """ Assumes input of size `[batch, chanel, *]`. """
         return (self.gamma * normed_x.transpose(1, -1) +
                 self.beta).transpose(1, -1)
 
@@ -27,11 +27,15 @@ class _LayerNorm(nn.Module):
 class GlobLN(_LayerNorm):
     """Global Layer Normalization (globLN)."""
     def forward(self, x):
-        """ Works for any input size > 2D.
+        """ Applies forward pass.
+        
+        Works for any input size > 2D.
+
         Args:
-            x: [batch, chan, *]
+            x (:class:`torch.Tensor`): Shape `[batch, chan, *]`
+
         Returns:
-            gLN_x: [batch, chan, *]
+            :class:`torch.Tensor`: gLN_x `[batch, chan, *]`
         """
         dims = list(range(1, len(x.shape)))
         mean = x.mean(dim=dims, keepdim=True)
@@ -42,11 +46,15 @@ class GlobLN(_LayerNorm):
 class ChanLN(_LayerNorm):
     """Channel-wise Layer Normalization (chanLN)."""
     def forward(self, x):
-        """ Works for any input size > 2D.
+        """ Applies forward pass.
+        
+        Works for any input size > 2D.
+
         Args:
-            x: [batch, chan, *]
+            x (:class:`torch.Tensor`): `[batch, chan, *]`
+
         Returns:
-            chanLN_x: [batch, chan, *]
+            :class:`torch.Tensor`: chanLN_x `[batch, chan, *]`
         """
         mean = torch.mean(x, dim=1, keepdim=True)
         var = torch.var(x, dim=1, keepdim=True, unbiased=False)
@@ -57,10 +65,11 @@ class CumLN(_LayerNorm):
     """Cumulative Global layer normalization(cumLN)."""
     def forward(self, x):
         """
+
         Args:
-            x: [batch, channels, length]
+            x (:class:`torch.Tensor`): Shape `[batch, channels, length]`
         Returns:
-            cumLN_x: [batch, channels, length]
+             :class:`torch.Tensor`: cumLN_x `[batch, channels, length]`
         """
         batch, chan, spec_len = x.size()
         cum_sum = torch.cumsum(x.sum(1, keepdim=True), dim=-1)

--- a/asteroid/utils.py
+++ b/asteroid/utils.py
@@ -47,7 +47,7 @@ def to_cuda(tensors):
             tensors[key] = to_cuda(tensors[key])
         return tensors
     raise TypeError('tensors must be a tensor or a list or dict of tensors. '
-                    ' Got tensor of type {}'.format(type(tensors)))
+                    ' Got tensors of type {}'.format(type(tensors)))
 
 
 def prepare_parser_from_dict(dic, parser=None):

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,28 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS     ?=
+SPHINXBUILD    ?= sphinx-build
+SPHINXAPIBUILD = sphinx-apidoc
+SOURCEDIR      = source
+BUILDDIR       = build
+CODEDIR        = ../asteroid
+APIDOCOUT      = "$(SOURCEDIR)"/apidoc
+
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+doc:
+	@echo "Generating doc"
+	@$(SPHINXAPIBUILD) -fTMe "$(CODEDIR)" -o "$(APIDOCOUT)"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,9 @@ extensions = [
 ]
 
 # Intersphinx config
-intersphinx_mapping = {'torch': ('https://pytorch.org/docs/master/', None)}
+intersphinx_mapping = {
+    'torch': ('https://pytorch.org/docs/master/', None),
+}
 
 # Napoleon config
 napoleon_include_special_with_doc = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,7 @@ extensions = [
 # Intersphinx config
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'torch': ('https://pytorch.org/docs/master/', None),
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,9 @@ extensions = [
     'sphinx.ext.viewcode',
 ]
 
+# Intersphinx config
+intersphinx_mapping = {'torch': ('https://pytorch.org/docs/master/', None)}
+
 # Napoleon config
 napoleon_include_special_with_doc = True
 napoleon_use_ivar = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,7 @@ extensions = [
 
 # Intersphinx config
 intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
     'torch': ('https://pytorch.org/docs/master/', None),
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,70 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'asteroid'
+copyright = '2019, Manuel Pariente, Samuele Cornell, Sunit Sivasankaran, Mathieu Hu'
+author = 'Manuel Pariente, Samuele Cornell, Sunit Sivasankaran, Mathieu Hu'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+]
+
+# Napoleon config
+napoleon_include_special_with_doc = True
+napoleon_use_ivar = True
+
+# Autodoc config
+autodoc_inherit_docstring = True
+autodoc_default_flags = ['members', 'inherited-members', 'show-inheritance']
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,7 @@ napoleon_use_ivar = True
 
 # Autodoc config
 autodoc_inherit_docstring = True
-autodoc_default_flags = ['members', 'inherited-members', 'show-inheritance']
+autodoc_default_flags = ['members', 'show-inheritance']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Welcome to asteroid's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   apidoc/asteroid
 
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. asteroid documentation master file, created by
+   sphinx-quickstart on Sat Dec  7 14:48:37 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to asteroid's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,539 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=torch.*
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=79
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,16 @@ numpy==1.16.4
 pandas>=0.23.4
 pypesq>=1.0
 pystoi>=0.2.2
+pytest==5.3.1
 scipy>=1.1.0
 seaborn>=0.9.0
 SoundFile>=0.10.2
+sphinx-rtd-theme==0.4.3
+sphinxcontrib-applehelp==1.0.1
+sphinxcontrib-devhelp==1.0.1
+sphinxcontrib-htmlhelp==1.0.2
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.2
+sphinxcontrib-serializinghtml==1.1.3
 torch>=1.3.0
 torchvision>=0.4.1
-pytest==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa>=0.6.2
 matplotlib>=3.0.2
 mir-eval>=0.5
-numpy>=1.15.4
+numpy==1.16.4
 pandas>=0.23.4
 pypesq>=1.0
 pystoi>=0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ matplotlib>=3.0.2
 mir-eval>=0.5
 numpy==1.16.4
 pandas>=0.23.4
-pypesq>=1.0
 pystoi>=0.2.2
 pytest==5.3.1
 scipy>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ seaborn>=0.9.0
 SoundFile>=0.10.2
 torch>=1.3.0
 torchvision>=0.4.1
+pytest==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ matplotlib>=3.0.2
 mir-eval>=0.5
 numpy==1.16.4
 pandas>=0.23.4
+pylint==2.4.4
 pystoi>=0.2.2
 pytest==5.3.1
 scipy>=1.1.0


### PR DESCRIPTION
# Main object
## Description
Pull request to autodoc repo from docstrings using Sphinx.

The current output of the build can be viewed at https://mhu-coder.github.io/AsSteroid/

The docstrings follow the google format (example available at https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html). In terms of content, it may be nice to settle on a clear idea before the code base becomes too large. What do you think?

The theme is read-the-doc, which can be changed and is independent of Sphinx. 

There are few things I am not quite sure about in what I have written in the docstrings but we can, hopefully, solve that during the code review process.

## How to build the doc locally

```bash
cd docs
make doc
make html
```
Then open `docs/build/html/index.html` with your favourite browser

## How to build the docs on travis
`.travis.yml` has been modified to deploy the doc to github pages. However, you may need to set up an access token from github and name it `GITHUB_PAGES` on travis to allow travis to publish on github.
### Token creation
On github, click on icon -> settings.  
On the settings page, click on the `Developper settings` tab (in the left, possibly the one at the very bottom the the list)  
Then click on the `Personal access token` tab on the left, then on the `Generate new token` button.
When selecting the scope `repo --> public_repo` is sufficient for travis to push to github.  
Then click on `Generate token` at the bottom of the page.  **Keep window open** as you won't be able to access the token if you leave the window.

### Add token on travis
Go to your project dashboard (the one displays the job logs) and click on `More options` --> `settings`.  
In the section `Environment variable`, name the new variable `GITHUB_PAGES` and paste the value displayed on github to the Value field.


# Minor doc-unrelated changes

## Pylint
`pylint` has been added to `requirement.txt`.  
`pylintc` has been created to limit line length to 80 chars and white list torch (I got errors for every single use of `torch.mean`, `torch.sum`, etc.

## Numpy version
I had to freeze version of numpy to 1.16.4 to install pytorch-lightning 0.5.3.2 (as this specific version of numpy is required by pytorch-lightning).

## PyPESQ
I had to remove pypesq from `requirements.txt` as `pip install -r requirements.txt` crashed with the error message:

```
ERROR: Command errored out with exit status 1:
   command: /Users/mathieu/anaconda/envs/assteroid/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/t_/bz57k6n56gv9wc910p_npgqm0000gn/T/pip-install-zdh6058_/pypesq/setup.py'"'"'; __file__='"'"'/private/var/folders/t_/bz57k6n56gv9wc910p_npgqm0000gn/T/pip-install-zdh6058_/pypesq/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /private/var/folders/t_/bz57k6n56gv9wc910p_npgqm0000gn/T/pip-wheel-hu3wkctc --python-tag cp36
       cwd: /private/var/folders/t_/bz57k6n56gv9wc910p_npgqm0000gn/T/pip-install-zdh6058_/pypesq/
  Complete output (19 lines):
  running bdist_wheel
  running build
  running build_py
  file numpy.py (for module numpy) not found
  creating build
  creating build/lib.macosx-10.7-x86_64-3.6
  creating build/lib.macosx-10.7-x86_64-3.6/pypesq
  copying pypesq/__init__.py -> build/lib.macosx-10.7-x86_64-3.6/pypesq
  file numpy.py (for module numpy) not found
  running build_ext
  building 'pesq_core' extension
  creating build/temp.macosx-10.7-x86_64-3.6
  creating build/temp.macosx-10.7-x86_64-3.6/pypesq
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/mathieu/anaconda/envs/assteroid/include -arch x86_64 -I/Users/mathieu/anaconda/envs/assteroid/include -arch x86_64 -I/Users/mathieu/anaconda/envs/assteroid/include/python3.6m -I/private/var/folders/t_/bz57k6n56gv9wc910p_npgqm0000gn/T/pip-install-zdh6058_/pypesq/.eggs/numpy-1.17.4-py3.6-macosx-10.7-x86_64.egg/numpy/core/include -c pypesq/pesq.c -o build/temp.macosx-10.7-x86_64-3.6/pypesq/pesq.o
  pypesq/pesq.c:2:25: fatal error: arrayobject.h: No such file or directory
   #include "arrayobject.h"
                           ^
  compilation terminated.
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for pypesq
```
